### PR TITLE
Add param to the encryption/decryption methods to handle AES128 encryption

### DIFF
--- a/ios/RCTAes/RCTAes.m
+++ b/ios/RCTAes/RCTAes.m
@@ -14,11 +14,11 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(encrypt:(NSString *)data key:(NSString *)key iv:(NSString *)iv
+RCT_EXPORT_METHOD(encrypt:(NSString *)data key:(NSString *)key iv:(NSString *)iv algorithm:(NSString *)algorithm
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSError *error = nil;
-    NSString *base64 = [AesCrypt encrypt:data key:key iv:iv];
+    NSString *base64 = [AesCrypt encrypt:data key:key iv:iv algorithm:algorithm];
     if (base64 == nil) {
         reject(@"encrypt_fail", @"Encrypt error", error);
     } else {
@@ -26,11 +26,11 @@ RCT_EXPORT_METHOD(encrypt:(NSString *)data key:(NSString *)key iv:(NSString *)iv
     }
 }
 
-RCT_EXPORT_METHOD(decrypt:(NSString *)base64 key:(NSString *)key iv:(NSString *)iv
+RCT_EXPORT_METHOD(decrypt:(NSString *)base64 key:(NSString *)key iv:(NSString *)iv algorithm:(NSString *)algorithm
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSError *error = nil;
-    NSString *data = [AesCrypt decrypt:base64 key:key iv:iv];
+    NSString *data = [AesCrypt decrypt:base64 key:key iv:iv algorithm:algorithm];
     if (data == nil) {
         reject(@"decrypt_fail", @"Decrypt failed", error);
     } else {

--- a/ios/RCTAes/lib/AesCrypt.h
+++ b/ios/RCTAes/lib/AesCrypt.h
@@ -8,8 +8,8 @@
 #import <Foundation/Foundation.h>
 
 @interface AesCrypt : NSObject
-+ (NSString *) encrypt: (NSString *)clearText  key: (NSString *)key iv: (NSString *)iv;
-+ (NSString *) decrypt: (NSString *)cipherText key: (NSString *)key iv: (NSString *)iv;
++ (NSString *) encrypt: (NSString *)clearText  key: (NSString *)key iv: (NSString *)iv algorithm: (NSString *)algorithm;
++ (NSString *) decrypt: (NSString *)cipherText key: (NSString *)key iv: (NSString *)iv algorithm: (NSString *)algorithm;
 + (NSString *) pbkdf2:(NSString *)password salt: (NSString *)salt cost: (NSInteger)cost length: (NSInteger)length;
 + (NSString *) hmac256: (NSString *)input key: (NSString *)key;
 + (NSString *) sha1: (NSString *)input;


### PR DESCRIPTION
 Currently the library handles AES256 but not AES128 correctly on iOS. This PR adds the algorithm as a param on iOS. On Android it is based on the key length. 

- [x] Handle AES128 on iOS
- [x] Update Readme 